### PR TITLE
Fix a bug where valid class would toggle incorrectly

### DIFF
--- a/addon/components/ya-input/component.js
+++ b/addon/components/ya-input/component.js
@@ -112,6 +112,8 @@ const YaInputComponent = Component.extend({
 
       return get(this, 'canShowErrors') ? 'is-invalid' : 'is-valid';
     }
+
+    return;
   },
 
   /**

--- a/tests/acceptance/main-test.js
+++ b/tests/acceptance/main-test.js
@@ -53,3 +53,16 @@ test('it validates when `shouldShowValidationErrors` is `true`', (assert) => {
     .fillInJobTitle('Fashion Model')
     .assertIsValid('job-title');
 });
+
+test('it shows the right validation when focused in', (assert) => {
+  assert.expect(3);
+
+  return new MainRoute(assert, { routeName: '/' })
+    .assertVisitUrl()
+    .fillInFirstName('Milton')
+    .focusOnByName('first-name')
+    .assertIsValid('first-name')
+    .fillInFirstName(null)
+    .focusOnByName('first-name')
+    .assertIsInvalid('first-name');
+});

--- a/tests/helpers/page-objects/base.js
+++ b/tests/helpers/page-objects/base.js
@@ -70,6 +70,10 @@ export default class PageObject {
     });
   }
 
+  focusOnByName(name) {
+    return this.then(() => this.findInputByName(name).focusout());
+  }
+
   // utils
   /**
    * Pauses a test so you can look around within a PageObject chain.


### PR DESCRIPTION
# WIP

A bug was introduced where the input would incorrectly use the wrong
validClass when a field was focused in.
