### PR TITLE
Fix a bug where valid class would toggle incorrectly

### DIFF
--- a/addon/components/ya-input/component.js
+++ b/addon/components/ya-input/component.js
@@ -25,7 +25,6 @@ const YaInputComponent = Component.extend({
   classNameBindings: ['validClass', 'type'],
   hasFocusedOnce: false,
   hasLostFocus: false,
-  hasInitialFocus: false,
 
   wrapped: oneWay('form.wrapped'),
   model: oneWay('wrapped.model'),
@@ -80,15 +79,14 @@ const YaInputComponent = Component.extend({
     set: defaultCPSetter
   }),
 
-  validClass: computed('errors.[]', 'field-name', 'canShowErrors', 'errorText', 'hasFocusedOnce', 'shouldShowValidationErrors', {
+  validClass: computed('errors.[]', 'model.errors', 'field-name', 'canShowErrors', 'errorText', 'hasFocusedOnce', 'shouldShowValidationErrors', {
     get() {
-      return this._getValidClass(get(this, 'model.errors'), get(this, 'field-name'));
+      return this._getValidClass(get(this, 'errors.length'), get(this, 'model.errors'), get(this, 'field-name'));
     }
   }),
 
   focusIn() {
     set(this, 'hasLostFocus', false);
-    set(this, 'hasInitialFocus', true);
   },
 
   focusOut() {
@@ -104,14 +102,16 @@ const YaInputComponent = Component.extend({
    * @param {String} fieldName
    * @return {String}
    */
-  _getValidClass(modelErrors, fieldName) {
+  _getValidClass(errorsCount, modelErrors, fieldName) {
     if (get(this, 'hasFocusedOnce') || get(this, 'shouldShowValidationErrors')) {
       if (this._hasDSError(modelErrors, fieldName)) {
         return 'is-invalid';
       }
 
-      return get(this, 'canShowErrors') ? 'is-invalid' : 'is-valid';
+      return (get(this, 'canShowErrors') || errorsCount > 0) ? 'is-invalid' : 'is-valid';
     }
+
+    return;
   },
 
   /**

--- a/tests/acceptance/main-test.js
+++ b/tests/acceptance/main-test.js
@@ -15,17 +15,27 @@ module('Acceptance | main', {
   }
 });
 
-test('it displays validation errors', (assert) => {
+test('it displays validation errors when inputs have focused out', (assert) => {
   assert.expect(4);
 
   return new MainRoute(assert, { routeName: '/' })
     .assertVisitUrl()
     .fillInFirstName('Milton')
     .fillInLastName('Waddams')
-    .fillInJobTitle(null)
+    .fillInJobTitle('Fashion Model')
     .assertIsValid('first-name')
     .assertIsValid('last-name')
-    .assertIsInvalid('job-title');
+    .assertIsValid('job-title');
+});
+
+test('it does not display validation errors when inputs have not focused out', (assert) => {
+  assert.expect(4);
+
+  return new MainRoute(assert, { routeName: '/' })
+    .assertVisitUrl()
+    .assertNoValidation('first-name')
+    .assertNoValidation('last-name')
+    .assertNoValidation('job-title');
 });
 
 test('it sets values and updates validation', (assert) => {
@@ -52,4 +62,17 @@ test('it validates when `shouldShowValidationErrors` is `true`', (assert) => {
     .assertIsInvalid('job-title')
     .fillInJobTitle('Fashion Model')
     .assertIsValid('job-title');
+});
+
+test('it shows the right validation when focused in', (assert) => {
+  assert.expect(3);
+
+  return new MainRoute(assert, { routeName: '/' })
+    .assertVisitUrl()
+    .fillInFirstName('Milton')
+    .focusInByName('first-name')
+    .assertIsValid('first-name')
+    .fillInFirstName(null)
+    .focusInByName('first-name')
+    .assertIsInvalid('first-name');
 });

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -7,10 +7,16 @@
   font-size: 36px;
 }
 
+#ember-testing-container input:focus {
+  border-style: dashed;
+}
+
 #ember-testing-container input.is-valid {
   color: green;
+  border-color: green;
 }
 
 #ember-testing-container input.is-invalid {
   color: red;
+  border-color: red;
 }

--- a/tests/helpers/page-objects/base.js
+++ b/tests/helpers/page-objects/base.js
@@ -70,6 +70,10 @@ export default class PageObject {
     });
   }
 
+  focusInByName(name) {
+    return this.then(() => this.findInputByName(name).focusin());
+  }
+
   // utils
   /**
    * Pauses a test so you can look around within a PageObject chain.

--- a/tests/helpers/page-objects/main.js
+++ b/tests/helpers/page-objects/main.js
@@ -28,4 +28,12 @@ export default class MainRoute extends PageObject {
       this.assert.ok(findWithAssert(`input.is-invalid[name="${name}"]`).length, `${name} input has validation errors`);
     });
   }
+
+  assertNoValidation(name) {
+    return this.then(() => {
+      const valid = find(`input.is-valid[name="${name}"]`).length;
+      const invalid = find(`input.is-invalid[name="${name}"]`).length;
+      this.assert.equal(valid + invalid, 0, `${name} input has not been validated`);
+    });
+  }
 }


### PR DESCRIPTION
A bug was introduced where the input would incorrectly show `is-valid` when focused in on an input with errors.
