### PR TITLE
Fix `canShowErrors` logic

### DIFF
--- a/addon/components/ya-input/component.js
+++ b/addon/components/ya-input/component.js
@@ -68,13 +68,13 @@ const YaInputComponent = Component.extend({
     }
   }),
 
-  canShowErrors: computed('errors.[]', 'hasLostFocus', 'shouldShowValidationErrors', {
+  canShowErrors: computed('errors.[]', 'hasFocusedOnce', 'shouldShowValidationErrors', {
     get() {
       const errorsCount = get(this, 'errors.length');
-      const hasLostFocus = get(this, 'hasLostFocus');
+      const hasFocusedOnce = get(this, 'hasFocusedOnce');
       const shouldShowValidationErrors = get(this, 'shouldShowValidationErrors');
 
-      return !!(errorsCount > 0 && (hasLostFocus || shouldShowValidationErrors));
+      return !!(errorsCount > 0 && (hasFocusedOnce || shouldShowValidationErrors));
     },
     set: defaultCPSetter
   }),

--- a/tests/acceptance/main-test.js
+++ b/tests/acceptance/main-test.js
@@ -76,3 +76,20 @@ test('it shows the right validation when focused in', (assert) => {
     .focusInByName('first-name')
     .assertIsInvalid('first-name');
 });
+
+test('it displays error text when invalid, and hides when valid', (assert) => {
+  assert.expect(6);
+
+  return new MainRoute(assert, { routeName: '/' })
+    .assertVisitUrl()
+    .fillInFirstName(null)
+    .assertIsInvalid('first-name')
+    .fillInFirstName('A')
+    .focusInByName('first-name')
+    .assertIsInvalid('first-name')
+    .assertDisplaysErrorText('first-name', 'is too short (minimum is 2 characters)')
+    .fillInFirstName('ABC')
+    .focusInByName('first-name')
+    .assertIsValid('first-name')
+    .assertNoErrorText('first-name');
+});

--- a/tests/dummy/app/templates/components/user-form.hbs
+++ b/tests/dummy/app/templates/components/user-form.hbs
@@ -12,7 +12,7 @@
         classBinding=":blah yaInput.validClass"
     }}
     {{#if yaInput.canShowErrors}}
-      {{yaInput.errorText}}
+      <span class="error-message {{yaInput.name}}">{{yaInput.errorText}}</span>
     {{/if}}
   {{/ya-input}}
 
@@ -27,7 +27,7 @@
         classBinding=":blah yaInput.validClass"
     }}
     {{#if yaInput.canShowErrors}}
-      {{yaInput.errorText}}
+      <span class="error-message {{yaInput.name}}">{{yaInput.errorText}}</span>
     {{/if}}
   {{/ya-input}}
 
@@ -42,7 +42,7 @@
         classBinding=":blah yaInput.validClass"
     }}
     {{#if yaInput.canShowErrors}}
-      {{yaInput.errorText}}
+      <span class="error-message {{yaInput.name}}">{{yaInput.errorText}}</span>
     {{/if}}
   {{/ya-input}}
   <button type="submit" {{action "save" on="click"}}>Save</button>

--- a/tests/helpers/page-objects/main.js
+++ b/tests/helpers/page-objects/main.js
@@ -36,4 +36,16 @@ export default class MainRoute extends PageObject {
       this.assert.equal(valid + invalid, 0, `${name} input has not been validated`);
     });
   }
+
+  assertDisplaysErrorText(fieldName, containsText) {
+    return this.then(() => {
+      this.assert.ok(findWithAssert(`.error-message.${fieldName}:contains("${containsText}")`).length, `${fieldName} has error message "${containsText}"`);
+    });
+  }
+
+  assertNoErrorText(fieldName) {
+    return this.then(() => {
+      this.assert.equal(find(`.error-message.${fieldName}`).length, 0, `${fieldName} has no error message`);
+    });
+  }
 }


### PR DESCRIPTION
With the update to `_getValidClass`, we can now rely on `hasFocusedOnce`
instead in the CP
